### PR TITLE
chore: CNX-9649 Bump viewer version to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2661,12 +2661,12 @@
       }
     },
     "node_modules/@speckle/objectloader": {
-      "version": "2.18.14",
-      "resolved": "https://registry.npmjs.org/@speckle/objectloader/-/objectloader-2.18.14.tgz",
-      "integrity": "sha512-snOHg8ZdX/OxOOijx//B80D0QCAv9s7L7hap23e1ApeUh7XhlZS53K7QmmUIx9MLCjf+V4WDy+5xBjKRkQmODQ==",
+      "version": "2.18.16",
+      "resolved": "https://registry.npmjs.org/@speckle/objectloader/-/objectloader-2.18.16.tgz",
+      "integrity": "sha512-YykdjxVkYlND+tgjHUL2I+Djaggm+w2v+UKZSIDSt7LVGIDg88JXJZ/JbO9B8ptx16i0E2oCQRuiTCntimoqZQ==",
       "dependencies": {
         "@babel/core": "^7.17.9",
-        "@speckle/shared": "^2.18.14",
+        "@speckle/shared": "^2.18.16",
         "core-js": "^3.21.1",
         "regenerator-runtime": "^0.13.7"
       },
@@ -2675,9 +2675,9 @@
       }
     },
     "node_modules/@speckle/shared": {
-      "version": "2.18.14",
-      "resolved": "https://registry.npmjs.org/@speckle/shared/-/shared-2.18.14.tgz",
-      "integrity": "sha512-AXYKQmT1VtQFN8n3/l0ObKR03YMshioYzq8UBLKVf+di0jWxBSBXpJsDhfgCh4UwN6lNO5pgjYJE6e09o2m26A==",
+      "version": "2.18.16",
+      "resolved": "https://registry.npmjs.org/@speckle/shared/-/shared-2.18.16.tgz",
+      "integrity": "sha512-I5/jmvbuOjDJYjFY04f3IsDnQ0/Rt6DQKekXWiuyfmuLUqsBvM9hbWZBsg3vPmvX2HFgfQxisZAD0bHwpNTb3A==",
       "dependencies": {
         "lodash": "^4.17.0",
         "lodash-es": "^4.17.21",
@@ -2729,27 +2729,37 @@
       }
     },
     "node_modules/@speckle/viewer": {
-      "version": "2.18.14",
-      "resolved": "https://registry.npmjs.org/@speckle/viewer/-/viewer-2.18.14.tgz",
-      "integrity": "sha512-yUjlDzKO0bdhM9BuPGJcsjed8i3hWYKfhTbB+b4iN+4KCngwqANkGUTJyMYYa1SBkwd4/FOn6NGvackH6nwVmg==",
+      "version": "2.18.16",
+      "resolved": "https://registry.npmjs.org/@speckle/viewer/-/viewer-2.18.16.tgz",
+      "integrity": "sha512-exIloJG6ZLDX5FgrxyTcbr1+7K3CXC8weKJkWc6d1nZITGiDZnPB6CG3ffEmudKEdbPirUpGuYX5QsqZvvcA5w==",
       "dependencies": {
-        "@speckle/objectloader": "^2.18.14",
+        "@speckle/objectloader": "^2.18.16",
+        "@speckle/shared": "^2.18.16",
         "@types/flat": "^5.0.2",
         "camera-controls": "^1.33.1",
-        "flat": "^5.0.2",
         "hold-event": "^0.1.0",
         "js-logger": "1.6.1",
         "lodash-es": "^4.17.21",
-        "rainbowvis.js": "^1.0.1",
         "string-to-color": "^2.2.2",
         "three": "^0.140.0",
         "three-mesh-bvh": "0.5.17",
         "tree-model": "1.0.7",
         "troika-three-text": "0.47.2",
-        "underscore": "1.13.6"
+        "type-fest": "^4.15.0"
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@speckle/viewer/node_modules/type-fest": {
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.18.2.tgz",
+      "integrity": "sha512-+suCYpfJLAe4OXS6+PPXjW3urOS4IoP9waSiLuXfLgqZODKw/aWwASvzqE886wA0kQgGy0mIWyhd87VpqIy6Xg==",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@tailwindcss/forms": {
@@ -5847,14 +5857,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/flat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "bin": {
-        "flat": "cli.js"
       }
     },
     "node_modules/flat-cache": {
@@ -9144,11 +9146,6 @@
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "peer": true
     },
-    "node_modules/rainbowvis.js": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/rainbowvis.js/-/rainbowvis.js-1.1.1.tgz",
-      "integrity": "sha512-/sFEGIfTRsGnVhNSVRWytNMSXadyqcDWW6LLoQs2EWg3R0IZylHp05/XjkqeG4gn0kSp3UE2M8uCPseahcHtuA=="
-    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -10678,11 +10675,6 @@
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
       "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
       "peer": true
-    },
-    "node_modules/underscore": {
-      "version": "1.13.6",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.6.tgz",
-      "integrity": "sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A=="
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",

--- a/pbiviz.json
+++ b/pbiviz.json
@@ -4,7 +4,7 @@
     "displayName": "Speckle PowerBI Viewer",
     "guid": "powerbiSpeckleVisualAA98F06515D847E8ACB33BAB487244E0",
     "visualClassName": "Visual",
-    "version": "2.19.0-rc",
+    "version": "2.19.0-rc2",
     "description": "An interactive 3D viewer for Speckle Data",
     "supportUrl": "https://speckle.community",
     "gitHubUrl": "https://github.com/specklesystems/speckle-powerbi-visuals"


### PR DESCRIPTION
Updates viewer with latest fixes on selection released since 2.18.14

And bump visual version to `rc2`
